### PR TITLE
Fix fetching full-length filenames

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -32,8 +32,12 @@ fn parse_file_listing(data : &[u8]) -> Option<FileEntry> {
         return None;
     }
 
-    let mut filename : Vec<u8> = vec![];
-    filename.extend_from_slice(&data[0..11]);
+    // Filename is up to 12 bytes, padded out with nul bytes we want to strip
+    let filename = data[0..12]
+        .iter()
+        .cloned()
+        .take_while(|i| *i != 0)
+        .collect();
 
     return Some(FileEntry {
         name: String::from_utf8(filename).unwrap(),


### PR DESCRIPTION
Before, we were fetching 11 bytes for filenames instead of 12. This also made it easy to miss that NUL bytes weren't being handled properly - I mistakenly thought that `String::from_utf8` was stripping them.